### PR TITLE
Add requests package  as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
 	url = 'https://github.com/dhhagan/py-openaq',
 	license = 'MIT',
 	packages = ['openaq'],
+	install_requires = ['requests'],
 	test_suite = 'tests',
 	classifiers = [
 		'Development Status :: 3 - Alpha',


### PR DESCRIPTION
The package [depends on the requests](https://github.com/dhhagan/py-openaq/blob/master/openaq/__init__.py#L5) package, which is not explicitly mentioned in the setup file. This PR adds this as requirement to the setup file.