### PR TITLE
Patch pd datelocal

### DIFF
--- a/openaq/decorators.py
+++ b/openaq/decorators.py
@@ -39,6 +39,14 @@ def pandasize():
                 if status == 200:
                     resp = resp['results']
 
+                    # Empty DataFrame when no results are returned
+                    if not resp:
+                        return pd.DataFrame(
+                            columns= ['date.local', 'city', 
+                                'coordinates.latitude', 'coordinates.longitude', 
+                                'country', 'date.utc', 'location', 
+                                'parameter', 'unit', 'value'])
+
                     if f.__name__ == 'latest':
                         d = []
                         for i in resp:

--- a/openaq/decorators.py
+++ b/openaq/decorators.py
@@ -45,7 +45,7 @@ def pandasize():
                             columns= ['date.local', 'city', 
                                 'coordinates.latitude', 'coordinates.longitude', 
                                 'country', 'date.utc', 'location', 
-                                'parameter', 'unit', 'value'])
+                                'parameter', 'unit', 'value']).set_index('date.local')
 
                     if f.__name__ == 'latest':
                         d = []

--- a/openaq/viz.py
+++ b/openaq/viz.py
@@ -89,6 +89,7 @@ def tsplot(data, time_col=None, ax=None, parameter=None, rs='1h',
 
     """
     assert isinstance(data, pd.DataFrame), "`data` must be a pandas dataframe"
+    assert len(data) > 0, "`data` to plot can not be an empty pandas dataframe"
     assert parameter in [None, 'pm25', 'pm10', 'o3', 'no2', 'bc', 'co', 'so2'], "Invalid parameter"
 
     if "figsize" not in plot_kws.keys():

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -14,6 +14,15 @@ class SetupTestCase(unittest.TestCase):
     def test_setup(self):
         self.assertIsInstance(self.api, openaq.OpenAQ)
 
+    def test_error_on_empty_df(self):
+        empty_df = pd.DataFrame(
+                            columns= ['date.local', 'city', 
+                                'coordinates.latitude', 'coordinates.longitude', 
+                                'country', 'date.utc', 'location', 
+                                'parameter', 'unit', 'value']).set_index('date.local')
+        with self.assertRaises(AssertionError):
+            tsplot(empty_df)
+
     def test_tsplot_1hr(self):
         data = self.api.measurements(
                     city='Delhi',


### PR DESCRIPTION
This PR tackles (partly) #10 by returning an empty DataFrame instead of an error message when no results are returned by the API (in combination with a status  200).

Some remarks:
- Returning empty DataFrame instead of error to be consistent with the `df=False` option also returning json with no results.
- Similar to other sections of the code with hard coded column names (e.g. `locations`,...), I also returned the `DataFrame` with a hard coded set of names.  
- I adjusted the plot function to assert an error when trying to plot an empty DataFrame and added a unit test for this.

The tests do still fail as the API is not returning any information. Fixing this is out of scope of this PR, as it would require having _fixture_ or mocked data as the input of the plot functions instead of relying on the API when running the tests.  

